### PR TITLE
Fix ReDoc CSP Headers and Consolidate Security Configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       # HTTPS Router
       - "traefik.http.routers.websecure-app.rule=Host(`${DEV_DOMAIN:-localhost}`)"
       - "traefik.http.routers.websecure-app.entrypoints=websecure"
-      - "traefik.http.routers.websecure-app.middlewares=cors-headers,secure-headers,security-headers,scheme-enforcer"
+      - "traefik.http.routers.websecure-app.middlewares=cors-headers,secure-headers,scheme-enforcer"
       - "traefik.http.routers.websecure-app.tls=true"
       # Service
       - "traefik.http.services.app.loadbalancer.server.port=8000"
@@ -74,15 +74,8 @@ services:
       # Middleware - Secure Headers
       - "traefik.http.middlewares.secure-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
       - "traefik.http.middlewares.secure-headers.headers.customrequestheaders.X-Forwarded-Host=localhost"
-      - "traefik.http.middlewares.secure-headers.headers.customresponseheaders.Strict-Transport-Security=max-age=31536000; includeSubDomains; preload"
       - "traefik.http.middlewares.secure-headers.headers.customresponseheaders.X-Scheme=https"
       - "traefik.http.middlewares.secure-headers.headers.hostsproxyheaders=X-Forwarded-Host,X-Forwarded-Proto,X-Real-IP"
-      # Middleware - Security Headers for Development
-      - "traefik.http.middlewares.security-headers.headers.customresponseheaders.Content-Security-Policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' https: http: data: blob: ws:; frame-ancestors 'self'; img-src 'self' https: http: data: blob:; font-src 'self' https: http: data:; form-action 'self'; media-src 'self' https: http: data: blob:; connect-src 'self' https: http: ws: wss:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https: http:; style-src 'self' 'unsafe-inline' https: http:;"
-      - "traefik.http.middlewares.security-headers.headers.customresponseheaders.X-Content-Type-Options=nosniff"
-      - "traefik.http.middlewares.security-headers.headers.customresponseheaders.X-Frame-Options=SAMEORIGIN"
-      - "traefik.http.middlewares.security-headers.headers.customresponseheaders.X-XSS-Protection=1; mode=block"
-      - "traefik.http.middlewares.security-headers.headers.customresponseheaders.Referrer-Policy=strict-origin-when-cross-origin"
       # Force HTTPS scheme for all requests
       - "traefik.http.middlewares.scheme-enforcer.headers.customrequestheaders.X-Forwarded-Proto=https"
 


### PR DESCRIPTION
## Description
This PR addresses the Content Security Policy (CSP) issues preventing ReDoc from functioning correctly and streamlines our security header management by making FastAPI the single source of truth.

## Changes Made
### Security Headers Consolidation
- Removed security headers from Traefik configuration to prevent conflicts
- Centralized all security header management in FastAPI middleware
- Implemented proper HSTS configuration

### CSP Configuration Updates
- Added required `worker-src` directive to support ReDoc Web Workers
- Configured `script-src` to allow necessary functionality
- Added support for CDN resources from jsdelivr.net
- Implemented separate CSP configurations for production and development

### Development Environment Improvements
- Enhanced development CSP configuration for better developer experience
- Maintained security while allowing necessary development tools
- Improved documentation accessibility

## Testing Done
- Verified ReDoc functionality in development environment
- Confirmed security headers are properly set
- Tested both development and production CSP configurations
- Validated CORS functionality

## Security Considerations
- Maintained strict CSP in production while allowing necessary resources
- Kept development environment more permissive for debugging
- Preserved essential security headers across all environments
- Implemented proper HSTS configuration

## Related Issues
Fixes #[issue_number] - ReDoc not functioning due to CSP restrictions

## Deployment Notes
- Requires restart of FastAPI application after deployment
- No database changes required
- Compatible with existing infrastructure

## Screenshots
![image](https://github.com/user-attachments/assets/992c94d7-6b83-4c21-8330-d03ffcca751f)